### PR TITLE
fix uninitialized variable error

### DIFF
--- a/driver/src/binScanf.cpp
+++ b/driver/src/binScanf.cpp
@@ -229,7 +229,7 @@ binVsscanf(const char *bufOrg, const char *s, va_list ap, int bufLen)
 	buf = bufOrg;
 	bufEnd = buf + bufLen;
 
-	count = noassign = width = lflag = 0;
+	count = noassign = width = lflag = base = 0;
 	// Parse Inputbuffer buf
 	while (*s && (buf < bufEnd))
 	{

--- a/tools/pcl_converter/src/pcl_converter.cpp
+++ b/tools/pcl_converter/src/pcl_converter.cpp
@@ -190,7 +190,7 @@ int numEchoOutput = 1;
              intensity = 0.0;
            }
         unsigned char r,g,b;
-        unsigned char grey;
+        unsigned char grey = 0;
           if (encodeIdx == 0) {
             grey = (unsigned char) intensity;
           }


### PR DESCRIPTION
There is an issue with the uninitialized variables in the code. It is very important to take care of them. You can find this when compiling with `catkin build`. I recommend to use `catkin build` instead of `catkin_make`, as you will have better code quality.