### PR TITLE
Fix writing of encoder settings to sensor

### DIFF
--- a/driver/src/sick_scan_common.cpp
+++ b/driver/src/sick_scan_common.cpp
@@ -1883,7 +1883,7 @@ namespace sick_scan
         // Uses sprintf-Mask to set bitencoded echos and rssi enable flag
         // sopasCmdMaskVec[CMD_SET_PARTIAL_SCANDATA_CFG] = "\x02sWN LMDscandatacfg %02d 00 %d %d 00 %d 00 0 0 0 1 1\x03";
         const char *pcCmdMask = sopasCmdMaskVec[CMD_SET_PARTIAL_SCANDATA_CFG].c_str();
-        sprintf(requestLMDscandatacfg, pcCmdMask, outputChannelFlagId, rssiFlag ? 1 : 0, rssiResolutionIs16Bit ? 1 : 0,EncoderSetings ? 1 : 0);
+        sprintf(requestLMDscandatacfg, pcCmdMask, outputChannelFlagId, rssiFlag ? 1 : 0, rssiResolutionIs16Bit ? 1 : 0,EncoderSetings != -1 ? EncoderSetings : 0);
         if (useBinaryCmd)
         {
           std::vector<unsigned char> reqBinary;


### PR DESCRIPTION
This patch fixes an issue while writing the enconder settings to sensors.
When the value is left default, the value written to the sensor is 1.
Writing 1 to lms15xx will enable output of encoder values in datagram,
and thus making the datagram parser to fail due to the additional data.