### PR TITLE
Disable debug build mode in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ macro(use_cxx11)
 	endif ()
 endmacro(use_cxx11)
 
-set(CMAKE_BUILD_TYPE Debug) #uncomment to activate debug mode for lib_sick as well
+#set(CMAKE_BUILD_TYPE Debug) #uncomment to activate debug mode for lib_sick as well
 # set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++03")
 
 # Switch on, if you use c11-specific commands


### PR DESCRIPTION
Comment `Debug` build mode accidentally(?) committed to `CMakeLists.txt` in 02b000f1.