### PR TITLE
Fix time_offset in binary mode

### DIFF
--- a/driver/src/sick_scan_common.cpp
+++ b/driver/src/sick_scan_common.cpp
@@ -2547,7 +2547,7 @@ namespace sick_scan
         bool FireEncoder=false;
         EncoderMsg.header.frame_id="Encoder";
         EncoderMsg.header.seq=numPacketsProcessed;
-        msg.header.stamp = recvTimeStamp;
+        msg.header.stamp = recvTimeStamp + ros::Duration(config_.time_offset);
         double elevationAngleInRad = 0.0;
         /*
          * datagrams are enclosed in <STX> (0x02), <ETX> (0x03) pairs
@@ -3277,7 +3277,7 @@ namespace sick_scan
               int numTmpLayer = numOfLayers;
 
 
-              cloud_.header.stamp = recvTimeStamp;
+              cloud_.header.stamp = recvTimeStamp + ros::Duration(config_.time_offset);
 
 
               cloud_.header.frame_id = config_.frame_id;


### PR DESCRIPTION
The `time_offset` in the [dynamic_reconfigure config](https://github.com/Intermodalics/sick_scan/blob/977059a87da8838e98fc4e558d792879354b48e5/cfg/SickScan.cfg#L63) was not applied in binary mode (the default, at least for TIM55x).