### PR TITLE
Fix undefined parameters and forwarding of min angle max angle in URDF models

### DIFF
--- a/urdf/sick_scan.urdf.xacro
+++ b/urdf/sick_scan.urdf.xacro
@@ -75,7 +75,7 @@
           izz="${0.0833333 * mass * (length * length + width * width)}" />
       </inertial>
     </link>
-    <xacro:sick_tim_laser_gazebo_v0 name="${name}" link="${name}" ros_topic="${ros_topic}" update_rate="15.0" min_angle="-2.357" max_angle="2.357" min_range="${min_range}" max_range="${max_range}" samples="${samples}"/>
+    <xacro:sick_tim_laser_gazebo_v0 name="${name}" link="${name}" ros_topic="${ros_topic}" update_rate="15.0" min_angle="${min_angle}" max_angle="${max_angle}" min_range="${min_range}" max_range="${max_range}" samples="${samples}"/>
   </xacro:macro>
 
 

--- a/urdf/sick_scan.urdf.xacro
+++ b/urdf/sick_scan.urdf.xacro
@@ -4,10 +4,11 @@
   xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
   xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:macro name="sick_tim_5xx" params="name ros_topic">
+  <xacro:macro name="sick_tim_5xx" params="name ros_topic min_angle:=-2.357 max_angle:=2.357 samples:=271">
     <xacro:sick_tim name="${name}" ros_topic="${ros_topic}"
       length="0.06" width="0.06" height="0.079" mass="0.150" z_offset="0.05595"
-      min_range="0.05" max_range="4.0" samples="271"
+      min_angle="${min_angle}" max_angle="${max_angle}"
+      min_range="0.05" max_range="4.0" samples="${samples}"
       mesh="package://sick_scan/meshes/sick_tim_5xx.stl" />
   </xacro:macro>
 
@@ -27,10 +28,11 @@
       mesh="package://sick_scan/meshes/sick_tim_5xx.stl" />
   </xacro:macro>
 
-  <xacro:macro name="sick_mrs_1xxx" params="name ros_topic">
+  <xacro:macro name="sick_mrs_1xxx" params="name ros_topic min_angle:=-2.357 max_angle:=2.357 samples:=271">
     <xacro:sick_tim name="${name}" ros_topic="${ros_topic}"
       length="0.06" width="0.06" height="0.079" mass="0.150" z_offset="0.05595"
-      min_range="0.05" max_range="4.0" samples="271"
+      min_angle="${min_angle}" max_angle="${max_angle}"
+      min_range="0.05" max_range="4.0" samples="${samples}"
       mesh="package://sick_scan/meshes/sick_tim_5xx.stl" />
   </xacro:macro>
 


### PR DESCRIPTION
Arguments `min_angle` and `max_angle` have been added to the `sick_tim` xacro macro in https://github.com/SICKAG/sick_scan/pull/69, but they have no default value and were not set in `sick_tim_5xx` and `sick_tim_56x`, which results in an xacro parsing error.

The second patch fixes the forwarding of these new parameters to the `sick_tim_laser_gazebo_v0` macro, which handles the simulation of laser scans in Gazebo.

I just noticed that there is already another pull request https://github.com/SICKAG/sick_scan/pull/69 to address the second issue, but not the first one.