### PR TITLE
Skip datagrams if the PLL was not locked

### DIFF
--- a/driver/src/sick_scan_common.cpp
+++ b/driver/src/sick_scan_common.cpp
@@ -2654,6 +2654,13 @@ namespace sick_scan
                   //ROS_INFO("%F,%F,%u,%u,%F",timestampfloat,timestampfloat_coor,SystemCountTransmit,SystemCountScan,DeltaTime);
                   //TODO Handle return values
 
+                  // Skip this datagram/scan if the PLL is not locked.
+                  // See https://github.com/SICKAG/sick_scan/issues/66#issuecomment-568726277.
+                  if (!bRet) {
+                    dataToProcess = false;
+                    break;
+                  }
+
 #ifdef DEBUG_DUMP_ENABLED
                   double elevationAngleInDeg=elevationAngleInRad = -elevAngleX200 / 200.0;
                   // DataDumper::instance().pushData((double)SystemCountScan, "LAYER", elevationAngleInDeg);


### PR DESCRIPTION
We observed the following timestamp hiccups with a SICK TIM551 LIDAR:

![image](https://user-images.githubusercontent.com/2506837/73982764-333dbd80-4935-11ea-904f-2e68901296b7.png)

The x axis represents receipt time on the host (via Ethernet), the y axis is the respective header timestamp as published by the `sick_generic_caller` node. I would understand some variable transport delay (messages shifted to the left or right), but the header stamps should progress in regular intervals, namely 66.6ms for a scan rate of 15Hz. In this case we received two different scans with the same header stamp between 126.9s and 127s in the plot.

Could this observation be related to the [time synchronization mechanism](https://github.com/SICKAG/sick_scan/blob/master/doc/timing.md) and https://github.com/SICKAG/sick_scan/issues/66, although this issue was for another device? Unfortunately we could not reproduce the issue anymore during the last days to verify whether the proposed patch is effective. But I would appreciate some feedback whether this is the workaround proposed in https://github.com/SICKAG/sick_scan/issues/66#issuecomment-568726277 (@michael1309).

Is there another way to make sure that header stamps are as close as possible to the actual capture time of the first ray, as specified in [sensor_msgs/LaserScan](http://docs.ros.org/melodic/api/sensor_msgs/html/msg/LaserScan.html), with the host's system time as the reference?

This is our current configuration:
```
scanner_type: sick_tim_5xx
min_ang: -2.15
max_ang: 2.15
use_binary_protocol: true
range_max: 100.0
intensity: true
hostname: x.x.x.x
cloud_topic: laser/cloud
frame_id: laser
port: 2112
timelimit: 5
```