### PR TITLE
fix some bugs for rms3xx & remove some logfiles

### DIFF
--- a/cfg/SickScan.cfg
+++ b/cfg/SickScan.cfg
@@ -68,7 +68,6 @@ gen.add("powerOnCount", int_t	,0, "Read only Power On counter at start up.",    
 gen.add("operationHours", double_t	,0, "Read only operationg hours [h].",                            0,0,6553.6)
 gen.add("locationName", str_t,0, "Device Location Name",""),
 gen.add("timelimit", double_t, 0, "Network time limit for datagram request [sec].",                             5.0, 0.1,100.0)
-gen.add("use_binary_protocol", bool_t, 0, "Force usage of binary protocol if true or ASCII if false, if not set default protocol is used.",                            True)
 gen.add("cloud_output_mode", int_t, 0, "[0] Pointcloud is dense all layers in one cloud,[1] Each layer in its own cloud message to improve timestamp accuracy,[2] layers are split to achieve approx. 1 KHz data rate",                            0,0,2)
 gen.add("ang_res",	    double_t, 0, "Angular resolution in deg/scan set to 0 to use scanner default",	0 ,0,10)
 gen.add("scan_freq",	double_t, 0, "Scan frequency set to 0 to use scanner default",0 ,0,100)

--- a/driver/src/sick_scan_common.cpp
+++ b/driver/src/sick_scan_common.cpp
@@ -2780,7 +2780,7 @@ namespace sick_scan
          */
         char *buffer_pos = (char *) receiveBuffer;
         char *dstart, *dend;
-        bool dumpDbg = true; // !!!!!
+        bool dumpDbg = false;
         bool dataToProcess = true;
         std::vector<float> vang_vec;
         vang_vec.clear();

--- a/include/sick_scan/sick_generic_radar.h
+++ b/include/sick_scan/sick_generic_radar.h
@@ -168,7 +168,7 @@ namespace sick_scan
 
     void simulateAsciiDatagramFromFile(unsigned char *receiveBuffer, int *actual_length, std::string filePattern);
 
-    bool emul;
+    bool emul = false;
 
     ros::NodeHandle nh_;
     ros::Publisher cloud_radar_rawtarget_pub_;


### PR DESCRIPTION
Hi, I stumbled on some issues using this driver that I fixed with these changes (using ros melodic on ubuntu 18.04) :
* the rms3xx only worked on the first launch, because the driver did set "use_binary_protocol" to true ; removing this option for dynamic_reconfigure fixes the issue
Anyway `use_binary_protocol` is only used at launch so it shouldn't be a dynamic parameter

* by default `bool emul;` is lef uninitialized : this leads to undefined behavior, especially when compiling with CMAKE_BUILD_TYPE in `Release` instead of `Debug`

* `dumpDbg` should be `false` by default, otherwise the driver will create a new file in `/tmp/...` for each scan

