### PR TITLE
Fix Gazebo sensor noise configuration

### DIFF
--- a/urdf/sick_lms1xx.urdf.xacro
+++ b/urdf/sick_lms1xx.urdf.xacro
@@ -4,13 +4,13 @@
   xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
   xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:macro name="sick_lms_1xx" params="name ros_topic">
+  <xacro:macro name="sick_lms_1xx" params="name ros_topic gaussian_noise:=0.006">
     <xacro:sick_lms_1 name="${name}" ros_topic="${ros_topic}"
       length="0.105636" width="0.102301" height="0.161782" mass="1.1" x_offset="0.052811" z_offset="-0.008195"
-      min_range="0.5" max_range="20.0"/>
+      min_range="0.5" max_range="20.0" gaussian_noise="${gaussian_noise}" />
   </xacro:macro>
 
-  <xacro:macro name="sick_lms_1" params="name ros_topic length width height mass x_offset z_offset min_range max_range">
+  <xacro:macro name="sick_lms_1" params="name ros_topic length width height mass x_offset z_offset min_range max_range gaussian_noise">
     <link name="${name}_mount_link">
       <visual>
         <geometry>
@@ -48,11 +48,11 @@
           iyy="0.000001" iyz="0.0" izz="0.000001" />
       </inertial>
     </link>
-    <xacro:sick_lms_1_laser_gazebo_v0 name="${name}" link="${name}_laser" ros_topic="${ros_topic}" update_rate="15.0" min_angle="-2.357" max_angle="2.357" min_range="${min_range}" max_range="${max_range}"/>
+    <xacro:sick_lms_1_laser_gazebo_v0 name="${name}" link="${name}_laser" ros_topic="${ros_topic}" update_rate="15.0" min_angle="-2.357" max_angle="2.357" min_range="${min_range}" max_range="${max_range}" gaussian_noise="${gaussian_noise}" />
   </xacro:macro>
 
 
-  <xacro:macro name="sick_lms_1_laser_gazebo_v0" params="name link ros_topic update_rate min_angle max_angle min_range max_range">
+  <xacro:macro name="sick_lms_1_laser_gazebo_v0" params="name link ros_topic update_rate min_angle max_angle min_range max_range gaussian_noise">
     <gazebo reference="${link}">
       <material value="Gazebo/Blue" />
       <sensor type="ray" name="${name}">
@@ -74,11 +74,13 @@
             <max>${max_range}</max>
             <resolution>0.01</resolution>
           </range>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>${gaussian_noise}</stddev>
+          </noise>
         </ray>
         <plugin name="gazebo_ros_${name}_controller" filename="libgazebo_ros_laser.so">
-          <gaussianNoise>0.005</gaussianNoise>
-          <alwaysOn>true</alwaysOn>
-          <updateRate>${update_rate}</updateRate>
           <topicName>${ros_topic}</topicName>
           <frameName>${link}</frameName>
         </plugin>

--- a/urdf/sick_lms5xx.urdf.xacro
+++ b/urdf/sick_lms5xx.urdf.xacro
@@ -5,13 +5,13 @@
   xmlns:xacro="http://ros.org/wiki/xacro">
 
 
-  <xacro:macro name="sick_lms_5xx" params="name ros_topic">
+  <xacro:macro name="sick_lms_5xx" params="name ros_topic gaussian_noise:=0.004">
     <xacro:sick_lms_5 name="${name}" ros_topic="${ros_topic}"
       length="0.159277" width="0.155002" height="0.196397" mass="3.7" x_offset="0.079205" z_offset="-0.053449"
-      min_range="1.0" max_range="80.0"/>
+      min_range="1.0" max_range="80.0" gaussian_noise="${gaussian_noise}" />
   </xacro:macro>
 
-  <xacro:macro name="sick_lms_5" params="name ros_topic length width height mass x_offset z_offset min_range max_range">
+  <xacro:macro name="sick_lms_5" params="name ros_topic length width height mass x_offset z_offset min_range max_range gaussian_noise">
     <link name="${name}_mount_link">
       <visual>
         <geometry>
@@ -49,10 +49,10 @@
           iyy="0.000001" iyz="0.0" izz="0.000001" />
       </inertial>
     </link>
-    <xacro:sick_lms_5_laser_gazebo_v0 name="${name}" link="${name}_laser" ros_topic="${ros_topic}" update_rate="50.0" min_angle="-1.65806" max_angle="1.65806" min_range="${min_range}" max_range="${max_range}"/>
+    <xacro:sick_lms_5_laser_gazebo_v0 name="${name}" link="${name}_laser" ros_topic="${ros_topic}" update_rate="50.0" min_angle="-1.65806" max_angle="1.65806" min_range="${min_range}" max_range="${max_range}" gaussian_noise="${gaussian_noise}" />
   </xacro:macro>
 
-  <xacro:macro name="sick_lms_5_laser_gazebo_v0" params="name link ros_topic update_rate min_angle max_angle min_range max_range">
+  <xacro:macro name="sick_lms_5_laser_gazebo_v0" params="name link ros_topic update_rate min_angle max_angle min_range max_range gaussian_noise">
     <gazebo reference="${link}">
       <material value="Gazebo/Blue" />
       <sensor type="ray" name="${name}">
@@ -74,11 +74,13 @@
             <max>${max_range}</max>
             <resolution>0.01</resolution>
           </range>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>${gaussian_noise}</stddev>
+          </noise>
         </ray>
         <plugin name="gazebo_ros_${name}_controller" filename="libgazebo_ros_laser.so">
-          <gaussianNoise>0.005</gaussianNoise>
-          <alwaysOn>true</alwaysOn>
-          <updateRate>${update_rate}</updateRate>
           <topicName>${ros_topic}</topicName>
           <frameName>${link}</frameName>
         </plugin>

--- a/urdf/sick_scan.urdf.xacro
+++ b/urdf/sick_scan.urdf.xacro
@@ -4,39 +4,39 @@
   xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
   xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:macro name="sick_tim_5xx" params="name ros_topic min_angle:=-2.357 max_angle:=2.357 samples:=271">
+  <xacro:macro name="sick_tim_5xx" params="name ros_topic min_angle:=-2.357 max_angle:=2.357 gaussian_noise:=0.01 samples:=271">
     <xacro:sick_tim name="${name}" ros_topic="${ros_topic}"
       length="0.06" width="0.06" height="0.079" mass="0.150" z_offset="0.05595"
       min_angle="${min_angle}" max_angle="${max_angle}"
-      min_range="0.05" max_range="4.0" samples="${samples}"
+      min_range="0.05" max_range="4.0" gaussian_noise="${gaussian_noise}" samples="${samples}"
       mesh="package://sick_scan/meshes/sick_tim_5xx.stl" />
   </xacro:macro>
 
-  <xacro:macro name="sick_tim_56x" params="name ros_topic min_angle:=-2.357 max_angle:=2.357 samples:=811">
+  <xacro:macro name="sick_tim_56x" params="name ros_topic min_angle:=-2.357 max_angle:=2.357 gaussian_noise:=0.01 samples:=811">
     <xacro:sick_tim name="${name}" ros_topic="${ros_topic}"
       length="0.06" width="0.06" height="0.079" mass="0.150" z_offset="0.05595"
       min_angle="${min_angle}" max_angle="${max_angle}"
-      min_range="0.05" max_range="10.0" samples="${samples}"
+      min_range="0.05" max_range="10.0" gaussian_noise="${gaussian_noise}" samples="${samples}"
       mesh="package://sick_scan/meshes/sick_tim_5xx.stl" />
   </xacro:macro>
 
-  <xacro:macro name="sick_tim_57x" params="name ros_topic min_angle:=-2.357 max_angle:=2.357 samples:=811">
+  <xacro:macro name="sick_tim_57x" params="name ros_topic min_angle:=-2.357 max_angle:=2.357 gaussian_noise:=0.01 samples:=811">
     <xacro:sick_tim name="${name}" ros_topic="${ros_topic}"
       length="0.06" width="0.06" height="0.079" mass="0.150" z_offset="0.05595"
       min_angle="${min_angle}" max_angle="${max_angle}"
-      min_range="0.05" max_range="25.0" samples="${samples}"
+      min_range="0.05" max_range="25.0" gaussian_noise="${gaussian_noise}" samples="${samples}"
       mesh="package://sick_scan/meshes/sick_tim_5xx.stl" />
   </xacro:macro>
 
-  <xacro:macro name="sick_mrs_1xxx" params="name ros_topic min_angle:=-2.357 max_angle:=2.357 samples:=271">
+  <xacro:macro name="sick_mrs_1xxx" params="name ros_topic min_angle:=-2.357 max_angle:=2.357 gaussian_noise:=0.015 samples:=271">
     <xacro:sick_tim name="${name}" ros_topic="${ros_topic}"
       length="0.06" width="0.06" height="0.079" mass="0.150" z_offset="0.05595"
       min_angle="${min_angle}" max_angle="${max_angle}"
-      min_range="0.05" max_range="4.0" samples="${samples}"
+      min_range="0.05" max_range="4.0" gaussian_noise="${gaussian_noise}" samples="${samples}"
       mesh="package://sick_scan/meshes/sick_tim_5xx.stl" />
   </xacro:macro>
 
-  <xacro:macro name="sick_tim" params="name ros_topic length width height mass z_offset min_angle max_angle min_range max_range samples mesh">
+  <xacro:macro name="sick_tim" params="name ros_topic length width height mass z_offset min_angle max_angle min_range max_range gaussian_noise samples mesh">
     <!-- z_offset: distance between base plate and laser center (= center of mesh) -->
     <link name="${name}_mount_link">
       <inertial>
@@ -75,11 +75,11 @@
           izz="${0.0833333 * mass * (length * length + width * width)}" />
       </inertial>
     </link>
-    <xacro:sick_tim_laser_gazebo_v0 name="${name}" link="${name}" ros_topic="${ros_topic}" update_rate="15.0" min_angle="${min_angle}" max_angle="${max_angle}" min_range="${min_range}" max_range="${max_range}" samples="${samples}"/>
+    <xacro:sick_tim_laser_gazebo_v0 name="${name}" link="${name}" ros_topic="${ros_topic}" update_rate="15.0" min_angle="${min_angle}" max_angle="${max_angle}" min_range="${min_range}" max_range="${max_range}" gaussian_noise="${gaussian_noise}" samples="${samples}" />
   </xacro:macro>
 
 
-  <xacro:macro name="sick_tim_laser_gazebo_v0" params="name link ros_topic update_rate min_angle max_angle min_range max_range samples">
+  <xacro:macro name="sick_tim_laser_gazebo_v0" params="name link ros_topic update_rate min_angle max_angle min_range max_range gaussian_noise samples">
     <gazebo reference="${link}">
       <material value="Gazebo/Blue" />
       <sensor type="ray" name="${name}">
@@ -101,11 +101,13 @@
             <max>${max_range}</max>
             <resolution>0.01</resolution>
           </range>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>${gaussian_noise}</stddev>
+          </noise>
         </ray>
         <plugin name="gazebo_ros_${name}_controller" filename="libgazebo_ros_laser.so">
-          <gaussianNoise>0.005</gaussianNoise>
-          <alwaysOn>true</alwaysOn>
-          <updateRate>${update_rate}</updateRate>
           <topicName>${ros_topic}</topicName>
           <frameName>${link}</frameName>
         </plugin>


### PR DESCRIPTION
The current sensor Xacro macros use an old method of adding noise to simulated Gazebo data that no longer works. Back in ROS Groovy, the [gazebo::GazeboRosLaser (Groovy)](https://docs.ros.org/en/groovy/api/gazebo_plugins/html/classgazebo_1_1GazeboRosLaser.html) plugin accepted the `gaussianNoise` parameter in order to add noise to Gazebo's range data before publishing that data to ROS. This parameter was removed with ROS Hydro ([gazebo::GazeboRosLaser (Hydro)](https://docs.ros.org/en/hydro/api/gazebo_plugins/html/classgazebo_1_1GazeboRosLaser.html)) in favor of Gazebo's native [SDF ray/noise](http://sdformat.org/spec?ver=1.8&elem=sensor#ray_noise) field.

This PR updates this package's Xacro macros to properly pass noise properties to Gazebo. It also adds an argument to each macro to allow manual configuration of the noise standard deviation. The default values are based on each sensor's statistical error under the assumption that that value represents 95% of the error distribution (i.e., 2σ).

The images below show simulated data from Gazebo before (left, no noise) and after (right, with noise) making these changes.

<p float="left">
  <img src="https://user-images.githubusercontent.com/7672143/123156794-56381700-d42f-11eb-982d-cb0b1e6251bd.png" width="400"/>
  <img src="https://user-images.githubusercontent.com/7672143/123156800-59330780-d42f-11eb-8197-4a6ead33104d.png" width="400"/>
</p>
